### PR TITLE
Add homepage to navbar

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -1,10 +1,15 @@
 [[navbar]]
+  identifier = "home"
+  name = "Home"
+  url = "../"
+  weight = 1
+[[navbar]]
   identifier = "list"
   name = "Positions"
   url = "/positions/"
-  weight = 1
+  weight = 2
 [[navbar]]
   identifier = "posts"
   name = "Posts"
   url = "/posts/"
-  weight = 2
+  weight = 3

--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -1,7 +1,7 @@
 [[navbar]]
   identifier = "home"
   name = "Home"
-  url = "../"
+  url = "https://markeverse.github.io"
   weight = 1
 [[navbar]]
   identifier = "list"


### PR DESCRIPTION
Hugo doesn't support cross-referencing variables, so have to use absolute URL. The main issue caused this was that when I moved into positions page, or posts, now we are 2 level down, and relative path via `../` doesn't work anywhere except home page of careers itself.